### PR TITLE
Fix loop termination bug in Tutorial 07 (Code + Docs)

### DIFF
--- a/docs/docs/07_loop_agents.md
+++ b/docs/docs/07_loop_agents.md
@@ -182,7 +182,7 @@ def exit_loop(tool_context: ToolContext):
     Called by the refiner when critic approves the essay.
     """
     print(f"  [Exit Loop] Called by {tool_context.agent_name} - Essay approved!")
-    tool_context.actions.end_of_agent = True  # Signal to stop looping
+    tool_context.actions.escalate = True  # Signal to stop looping
     # Return a minimal valid content part so the backend always produces a valid LlmResponse
     return {"text": "Loop exited successfully. The agent has determined the task is complete."}
 

--- a/tutorial_implementation/tutorial07/essay_refiner/agent.py
+++ b/tutorial_implementation/tutorial07/essay_refiner/agent.py
@@ -10,7 +10,7 @@ def exit_loop(tool_context: ToolContext):
     Called by the refiner when critic approves the essay.
     """
     print(f"  [Exit Loop] Called by {tool_context.agent_name} - Essay approved!")
-    tool_context.actions.end_of_agent = True  # Signal to stop looping
+    tool_context.actions.escalate = True  # Signal to stop looping
     # Return a minimal valid content part so the backend always produces a valid LlmResponse
     return {"text": "Loop exited successfully. The agent has determined the task is complete."}
 


### PR DESCRIPTION
The loop was incorrectly hitting max_iterations because the code used end_of_agent = True. This command successfully stopped the Refiner (the child agent), but failed to signal the parent RefinementLoop to terminate.

I have updated both agent.py and the documentation (07_loop_agents.md) to use escalate = True. This ensures the stop signal propagates up to the LoopAgent, allowing it to exit early as intended.

Evidence of bug:
<img width="2551" height="950" alt="image" src="https://github.com/user-attachments/assets/5f96829d-12d5-4dc0-a96e-299fcc82c2b6" />
